### PR TITLE
Add unit tests for AWS S3 destination

### DIFF
--- a/internal/destregistry/providers/destawss3/destawss3_format_test.go
+++ b/internal/destregistry/providers/destawss3/destawss3_format_test.go
@@ -1,0 +1,71 @@
+package destawss3_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/hookdeck/outpost/internal/destregistry/providers/destawss3"
+	"github.com/hookdeck/outpost/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAWSS3Publisher_Format(t *testing.T) {
+	fixedTime := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	event := models.Event{
+		ID:    "event-123",
+		Time:  fixedTime,
+		Topic: "topic",
+		Metadata: map[string]string{
+			"meta_key": "meta_value",
+		},
+		Data: map[string]interface{}{"hello": "world"},
+	}
+
+	publisher := destawss3.NewAWSS3Publisher(
+		nil,
+		"my-bucket",
+		"events/",
+		".json",
+		"STANDARD",
+		true,
+		true,
+	)
+
+	input, err := publisher.Format(context.Background(), &event)
+	require.NoError(t, err)
+
+	expectedKey := "events/" + fixedTime.Format(time.RFC3339Nano) + "_" + event.ID + ".json"
+	assert.Equal(t, "my-bucket", *input.Bucket)
+	assert.Equal(t, expectedKey, *input.Key)
+	assert.Equal(t, types.StorageClassStandard, input.StorageClass)
+	assert.Equal(t, "application/json", *input.ContentType)
+	assert.Equal(t, map[string]string(event.Metadata), input.Metadata)
+
+	// Verify checksum
+	data, _ := json.Marshal(event.Data)
+	hasher := sha256.Sum256(data)
+	expectedChecksum := base64.StdEncoding.EncodeToString(hasher[:])
+	assert.Equal(t, expectedChecksum, *input.ChecksumSHA256)
+}
+
+func TestAWSS3Publisher_Format_InvalidStorageClass(t *testing.T) {
+	publisher := destawss3.NewAWSS3Publisher(
+		nil,
+		"my-bucket",
+		"",
+		"",
+		"INVALID",
+		true,
+		true,
+	)
+
+	event := models.Event{ID: "id", Time: time.Now()}
+	_, err := publisher.Format(context.Background(), &event)
+	assert.Error(t, err)
+}

--- a/internal/destregistry/providers/destawss3/destawss3_validate_test.go
+++ b/internal/destregistry/providers/destawss3/destawss3_validate_test.go
@@ -1,0 +1,129 @@
+package destawss3_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hookdeck/outpost/internal/destregistry"
+	"github.com/hookdeck/outpost/internal/destregistry/providers/destawss3"
+	"github.com/hookdeck/outpost/internal/util/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAWSS3Destination_Validate(t *testing.T) {
+	t.Parallel()
+
+	validDestination := testutil.DestinationFactory.Any(
+		testutil.DestinationFactory.WithType("aws_s3"),
+		testutil.DestinationFactory.WithConfig(map[string]string{
+			"bucket":        "my-bucket",
+			"region":        "us-east-1",
+			"key_prefix":    "events/",
+			"key_suffix":    ".json",
+			"storage_class": "STANDARD",
+		}),
+		testutil.DestinationFactory.WithCredentials(map[string]string{
+			"key":     "test-key",
+			"secret":  "test-secret",
+			"session": "test-session",
+		}),
+	)
+
+	awsS3Destination, err := destawss3.New(testutil.Registry.MetadataLoader())
+	require.NoError(t, err)
+
+	t.Run("should validate valid destination", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, awsS3Destination.Validate(context.Background(), &validDestination))
+	})
+
+	t.Run("should validate invalid type", func(t *testing.T) {
+		t.Parallel()
+		invalidDestination := validDestination
+		invalidDestination.Type = "invalid"
+		err := awsS3Destination.Validate(context.Background(), &invalidDestination)
+		var validationErr *destregistry.ErrDestinationValidation
+		assert.ErrorAs(t, err, &validationErr)
+		assert.Equal(t, "type", validationErr.Errors[0].Field)
+		assert.Equal(t, "invalid_type", validationErr.Errors[0].Type)
+	})
+
+	t.Run("should validate missing bucket", func(t *testing.T) {
+		t.Parallel()
+		invalidDestination := validDestination
+		invalidDestination.Config = map[string]string{
+			"region": "us-east-1",
+		}
+		err := awsS3Destination.Validate(context.Background(), &invalidDestination)
+		var validationErr *destregistry.ErrDestinationValidation
+		assert.ErrorAs(t, err, &validationErr)
+		assert.Equal(t, "config.bucket", validationErr.Errors[0].Field)
+		assert.Equal(t, "required", validationErr.Errors[0].Type)
+	})
+
+	t.Run("should validate missing region", func(t *testing.T) {
+		t.Parallel()
+		invalidDestination := validDestination
+		invalidDestination.Config = map[string]string{
+			"bucket": "my-bucket",
+		}
+		err := awsS3Destination.Validate(context.Background(), &invalidDestination)
+		var validationErr *destregistry.ErrDestinationValidation
+		assert.ErrorAs(t, err, &validationErr)
+		assert.Equal(t, "config.region", validationErr.Errors[0].Field)
+		assert.Equal(t, "required", validationErr.Errors[0].Type)
+	})
+
+	t.Run("should validate malformed region", func(t *testing.T) {
+		t.Parallel()
+		invalidDestination := validDestination
+		invalidDestination.Config = map[string]string{
+			"bucket": "my-bucket",
+			"region": "invalid-region",
+		}
+		err := awsS3Destination.Validate(context.Background(), &invalidDestination)
+		var validationErr *destregistry.ErrDestinationValidation
+		assert.ErrorAs(t, err, &validationErr)
+		assert.Equal(t, "config.region", validationErr.Errors[0].Field)
+		assert.Equal(t, "pattern", validationErr.Errors[0].Type)
+	})
+
+	t.Run("should validate invalid storage class", func(t *testing.T) {
+		t.Parallel()
+		invalidDestination := validDestination
+		invalidDestination.Config["storage_class"] = "INVALID"
+		err := awsS3Destination.Validate(context.Background(), &invalidDestination)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid storage class")
+	})
+
+	t.Run("should validate missing credentials", func(t *testing.T) {
+		t.Parallel()
+		invalidDestination := validDestination
+		invalidDestination.Credentials = map[string]string{}
+		err := awsS3Destination.Validate(context.Background(), &invalidDestination)
+		var validationErr *destregistry.ErrDestinationValidation
+		assert.ErrorAs(t, err, &validationErr)
+		assert.Contains(t, []string{"credentials.key", "credentials.secret"}, validationErr.Errors[0].Field)
+		assert.Equal(t, "required", validationErr.Errors[0].Type)
+	})
+}
+
+func TestAWSS3Destination_ComputeTarget(t *testing.T) {
+	t.Parallel()
+
+	awsS3Destination, err := destawss3.New(testutil.Registry.MetadataLoader())
+	require.NoError(t, err)
+
+	destination := testutil.DestinationFactory.Any(
+		testutil.DestinationFactory.WithType("aws_s3"),
+		testutil.DestinationFactory.WithConfig(map[string]string{
+			"bucket": "my-bucket",
+			"region": "us-east-1",
+		}),
+	)
+
+	target := awsS3Destination.ComputeTarget(&destination)
+	assert.Equal(t, "my-bucket in us-east-1", target.Target)
+}


### PR DESCRIPTION
## Summary
- add validation tests for destawss3 provider
- test S3 publisher formatting and error cases

## Testing
- `go test ./internal/destregistry/providers/destawss3 -short`
- `go test ./... -short` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c8158d0c832ab381bb1d768e84bc