### PR TITLE
Add aws_s3 destination docs

### DIFF
--- a/docs/pages/concepts.mdx
+++ b/docs/pages/concepts.mdx
@@ -48,6 +48,7 @@ Event destination types belonging to Outpost tenants where events are delivered.
 - **Webhooks**
 - **RabbitMQ**
 - **AWS SQS**
+- **AWS S3**
 - **Hookdeck Event Gateway**
 - **[Amazon EventBridge (planned)](https://github.com/hookdeck/outpost/issues/201)**
 - **[Azure Service Bus (planned)](https://github.com/hookdeck/outpost/issues/241)**

--- a/docs/pages/features.mdx
+++ b/docs/pages/features.mdx
@@ -5,7 +5,7 @@ title: Outpost Features
 Outpost offers a range of features designed to provide a robust and flexible event delivery system. Explore the details of each feature below:
 
 - **[Multi-Tenant Support](./features/multi-tenant-support.mdx)**: The Outpost API supports creating multiple tenants on a single Outpost deployment.
-- **[Event Destinations](./features/destinations.mdx)**: Outpost supports a variety of event destination types, including Webhooks, Hookdeck Event Gateway, Amazon EventBridge, AWS SQS, AWS SNS, GCP Pub/Sub, RabbitMQ, and Kafka.
+- **[Event Destinations](./features/destinations.mdx)**: Outpost supports a variety of event destination types, including Webhooks, Hookdeck Event Gateway, Amazon EventBridge, AWS SQS, AWS SNS, AWS S3, GCP Pub/Sub, RabbitMQ, and Kafka.
 - **[Topics](./features/topics.mdx)**: Outpost supports event topics (also known as "event types") in order to segment, filter, and route events to appropriate destinations.
 - **[Publishing Events](./features/publish-events.mdx)**: Learn how events are published, either to a configured message queue or via the publish API endpoint.
 - **[Delivery & Retries](./features/event-delivery.mdx)**: Understand how Outpost ensures reliable event delivery with support for various destination types, retries, and best practices.
@@ -23,5 +23,5 @@ Outpost offers a range of features designed to provide a robust and flexible eve
 - **Multi-tenant support**: Create multiple tenants on a single Outpost deployment.
 - **Delivery failure alerts**: Manage event delivery failure alerts.
 - **OpenTelemetry**: OTel standardized traces, metrics, and logs.
-- **Event destination types**: Out of the box support for Webhooks, Hookdeck Event Gateway, Amazon EventBridge, AWS SQS, AWS SNS. GCP Pub/Sub, RabbitMQ, and Kafka.
+- **Event destination types**: Out of the box support for Webhooks, Hookdeck Event Gateway, Amazon EventBridge, AWS SQS, AWS SNS, AWS S3. GCP Pub/Sub, RabbitMQ, and Kafka.
 - **Webhook best practices**: Opt-out webhook best practices, such as headers for idempotency, timestamp and signature, and signature rotation.

--- a/docs/pages/features/destinations.mdx
+++ b/docs/pages/features/destinations.mdx
@@ -8,6 +8,7 @@ Outpost supports multiple event destination types. Each tenant can have multiple
 - Hookdeck Event Gateway
 - AWS SQS
 - AWS Kinesis
+- AWS S3
 - RabbitMQ (AMQP)
 
 Plans for additional event destination types include:

--- a/docs/pages/guides/migrate-to-outpost.mdx
+++ b/docs/pages/guides/migrate-to-outpost.mdx
@@ -6,7 +6,7 @@ This guide will help you migrate your existing webhook infrastructure to Outpost
 
 ## Why Migrate to Outpost?
 
-Outpost is a self-hosted and open-source infrastructure that enables event producers to add Event Destinations to their platform with support for destination types such as Webhooks, Hookdeck Event Gateway, Amazon EventBridge, AWS SQS, AWS SNS, GCP Pub/Sub, RabbitMQ, and Kafka.
+Outpost is a self-hosted and open-source infrastructure that enables event producers to add Event Destinations to their platform with support for destination types such as Webhooks, Hookdeck Event Gateway, Amazon EventBridge, AWS SQS, AWS SNS, AWS S3, GCP Pub/Sub, RabbitMQ, and Kafka.
 
 The benefits of migrating to Outpost include:
 
@@ -47,7 +47,7 @@ The following sections outline the key considerations when migrating webhook inf
 Outpost has the following concepts that you need to map to your existing webhook infrastructure provider:
 
 - **Tenants**: A tenant represents a customer organization.
-- **Destination Types**: The type of destination where events will be delivered. For example, webhook, Hookdeck Event Gateway, or AWS SQS.
+- **Destination Types**: The type of destination where events will be delivered. For example, webhook, Hookdeck Event Gateway, or AWS SQS or AWS S3.
 - **Destinations**: A subscription configured to deliver the event to a destination type. For example, a webhook destination with a specific URL.
 - **Events**: An event is a piece of data that represents an action that occurred in your system. For example, a user signed up or a payment was processed.
 - **Topics**: A topic is a way to categorize events and is a common concept found in Pub/Sub messaging. For example, a `user.created`.

--- a/docs/pages/overview.mdx
+++ b/docs/pages/overview.mdx
@@ -11,6 +11,7 @@ Outpost supports event delivery to:
 - RabbitMQ
 - AWS SQS
 - AWS Kinesis
+- AWS S3
 
 Planned destination types include AWS EventBridge, GCP Pub/Sub, and Kafka.
 


### PR DESCRIPTION
## Summary
- document AWS S3 as a supported destination type
- mention AWS S3 in concepts and guides

## Testing
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e8be8b84832a998e508e89018ecd